### PR TITLE
[#22]  init.sql score 테이블 생성 쿼리 FK refrence 부분 오류 수정

### DIFF
--- a/etc/sql/init.sql
+++ b/etc/sql/init.sql
@@ -34,19 +34,5 @@ CREATE TABLE score (
     total_score INT NOT NULL DEFAULT 0,
     modified_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-    FOREIGN KEY (user_id) REFERENCES user(user_id)
+    FOREIGN KEY (user_id) REFERENCES user(id)
 );
-
-
--- 기존 테이블 속성에서 user_id 속성을 UNIQUE로 설정
-ALTER TABLE `user`
-ADD CONSTRAINT `user_id`
-UNIQUE (`user_id`);
-
-ALTER TABLE `quiz`
-ADD CONSTRAINT `word`
-UNIQUE (`word`);
-
-ALTER TABLE `score`
-ADD CONSTRAINT `user_id`
-UNIQUE (`user_id`);


### PR DESCRIPTION
## 📝 작업 내용

- score 테이블 생성 쿼리 오류 수정
### before
FOREIGN KEY (user_id) REFERENCES user(**user_id**)

### after
FOREIGN KEY (user_id) REFERENCES user(**id**)

## ⭐️ 중점적으로 봐야 할 부분

![image](https://github.com/DevSimpleQuiz/Backend/assets/74135462/2f453543-1f5f-486c-924d-478b6c84697c)

