### PR TITLE
[#71] 회원탈퇴, 무한 퀴즈 챌린지 데이터 삭제

### DIFF
--- a/src/controllers/userController.js
+++ b/src/controllers/userController.js
@@ -368,9 +368,14 @@ const removeUserAccount = async (req, res, next) => {
     try {
       await connection.beginTransaction();
 
-      // user, score, solved_quizzes 테이블 속 계정 삭제
+      // 유저의 퀴즈 점수, 통계, 무한 퀴즈 챌린지, 유저 데이터 삭제
       await connection.query(scoreQuery.removeUserScoreHistory, userNumId);
       await connection.query(quizQuery.removeUserSolvedQuizHistory, userNumId);
+      await connection.query(quizQuery.removeUserInfiniteQuizDetail, userNumId);
+      await connection.query(
+        quizQuery.removeUserInfiniteQuizSummary,
+        userNumId
+      );
       // user id를 FK로 가진 테이블의 데이터들부터 삭제한 뒤에 user 테이블에서 유저 정보 삭제
       await connection.query(userQuery.removeUserAccount, userNumId);
 

--- a/src/queries/quizQuery.js
+++ b/src/queries/quizQuery.js
@@ -15,6 +15,8 @@ exports.updateQuizStatistics = `UPDATE quiz_accuracy_statistics \
                                         total_attempts_count_before_correct = total_attempts_count_before_correct + ? \
                                     WHERE quiz_id = ?`;
 exports.removeUserSolvedQuizHistory = `DELETE FROM solved_quizzes WHERE user_id = ?`;
+exports.removeUserInfiniteQuizDetail = `DELETE FROM infinite_quiz_detail WHERE user_id = ?`;
+exports.removeUserInfiniteQuizSummary = `DELETE FROM infinite_quiz_summary WHERE user_id = ?`;
 
 exports.addInfiniteChallengeSummary = `INSERT INTO infinite_quiz_summary (user_id) VALUES (?)`;
 exports.addInfiniteQuizChallengeDetail = `INSERT INTO infinite_quiz_detail (challenge_id, user_id) VALUES(?, ?)`;


### PR DESCRIPTION
## 📝 작업 내용

- 회원 탈퇴 시, 회원의 무한 퀴즈 챌린지 데이터 삭제

### 삭제 전
![image](https://github.com/user-attachments/assets/5ee5302a-0c46-4257-93cc-66d674e628eb)

### 삭제 후
![image](https://github.com/user-attachments/assets/f37ed7f6-9b3c-4298-a05b-f38718cc0ad7)

![image](https://github.com/user-attachments/assets/025073bb-a6d7-460e-b5e3-2cc881717a65)
![image](https://github.com/user-attachments/assets/e9f3679a-31ed-421c-b72a-a825a89ab6ea)


## ⭐️ 중점적으로 봐야 할 부분

- 회원 탈퇴 시 유저 데이터(퀴즈, 무한 퀴즈 챌린지 등등)들이 정상적으로 삭제 되는지

## 💬 리뷰 요구사항(선택)

- 현재의 방식에서는 회원 탈퇴할 때 데이터를 다 삭제하므로 복구가 불가능합니다.
- 회원 탈퇴하고 복구를 위해 1년 간은 데이터를 복구할 수 있게 하는 정책이 있던데 이런 방향으로 추후에 해볼까요?
